### PR TITLE
Add bundled OpenSSL backend for uv Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ playground.py
 !static_mem_bio.c
 !certdecode.c
 !aiofastnet/openssl_compat.c
+!aiofastnet/openssl_bundled.c
 .coverage
 uv.lock

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,5 @@ include aiofastnet/static_mem_bio.c
 include aiofastnet/static_mem_bio.h
 include aiofastnet/openssl_compat.h
 include aiofastnet/openssl_compat.c
+include aiofastnet/openssl_bundled.c
+include scripts/build_openssl.sh

--- a/aiofastnet/__init__.py
+++ b/aiofastnet/__init__.py
@@ -1,7 +1,7 @@
-# Fail early if python distribution is statically linked against OpenSSL
 import socket
 
 from .openssl_compat import OPENSSL_DYN_LIBS
+from ._sslcontext import SSLContext
 
 from .api_streams import (
     open_connection,
@@ -24,6 +24,7 @@ from .transport import (
 
 __all__ = [
     'OPENSSL_DYN_LIBS',
+    'SSLContext',
     'open_connection',
     'start_server',
     'create_server',

--- a/aiofastnet/__init__.pyi
+++ b/aiofastnet/__init__.pyi
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from .openssl_compat import OpenSSLDynLibs as OpenSSLDynLibs
+from ._sslcontext import SSLContext as SSLContext
 from .transport import (
     Protocol as Protocol,
     Transport as Transport,

--- a/aiofastnet/_sslcontext.py
+++ b/aiofastnet/_sslcontext.py
@@ -1,0 +1,49 @@
+import ssl
+
+
+class SSLContext(ssl.SSLContext):
+    """An ``ssl.SSLContext`` that records configuration which cannot be read back
+    from a plain context.
+
+    aiofastnet's *borrow* backend reuses the ``SSL_CTX`` that lives inside a
+    Python ``ssl.SSLContext`` directly, so it needs no help. The *bundled*
+    backend (a statically linked OpenSSL, used on Python distributions whose
+    ``_ssl`` is statically linked -- e.g. uv's python-build-standalone) must
+    build its *own* ``SSL_CTX`` and therefore has to reproduce the caller's
+    configuration. Most settings are readable from a plain context
+    (``verify_mode``, ``minimum_version``, CA certs via ``get_ca_certs`` ...),
+    but loaded certificate chains, verify locations, ALPN protocols and cipher
+    strings are not -- so they are recorded here for replay.
+
+    Use this exactly like ``ssl.SSLContext``. On the borrow backend it behaves
+    identically; only the bundled backend consumes the recorded calls.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # ssl.SSLContext fully initializes the underlying C object in __new__
+        # (which receives the protocol); forwarding args to object.__init__ would
+        # raise, so we only set up our own state here.
+        # list of (method_name, args_tuple, kwargs_dict)
+        self._aiofastnet_config = []
+
+    def load_cert_chain(self, *args, **kwargs):
+        result = super().load_cert_chain(*args, **kwargs)
+        self._aiofastnet_config.append(("load_cert_chain", args, dict(kwargs)))
+        return result
+
+    def load_verify_locations(self, *args, **kwargs):
+        result = super().load_verify_locations(*args, **kwargs)
+        self._aiofastnet_config.append(
+            ("load_verify_locations", args, dict(kwargs)))
+        return result
+
+    def set_alpn_protocols(self, protocols):
+        result = super().set_alpn_protocols(protocols)
+        self._aiofastnet_config.append(
+            ("set_alpn_protocols", (list(protocols),), {}))
+        return result
+
+    def set_ciphers(self, cipherlist):
+        result = super().set_ciphers(cipherlist)
+        self._aiofastnet_config.append(("set_ciphers", (cipherlist,), {}))
+        return result

--- a/aiofastnet/api_create_server.py
+++ b/aiofastnet/api_create_server.py
@@ -14,6 +14,7 @@ import sys
 
 from .api_utils import _is_asyncio_loop, _check_ssl_socket, _logger, _HAS_IPv6, _ensure_resolved, \
     _validate_ssl_timeout, _validate_bio_size, Server
+from .ssl_object import aiofn_preflight_server_context
 from .ssl_transport import SSLTransport_Transport
 from .transport import (aiofn_is_buffered_protocol)
 from .wrapped_transport import (
@@ -56,6 +57,10 @@ async def create_server(
     """
     if isinstance(ssl, bool):
         raise TypeError('ssl argument must be an SSLContext or None')
+
+    if ssl is not None:
+        # Surface a clear error at create time (bundled backend); no-op otherwise.
+        aiofn_preflight_server_context(ssl)
 
     ssl_handshake_timeout = _validate_ssl_timeout("ssl_handshake_timeout", ssl_handshake_timeout, ssl)
     ssl_shutdown_timeout = _validate_ssl_timeout("ssl_shutdown_timeout", ssl_shutdown_timeout, ssl)

--- a/aiofastnet/api_create_unix_server.py
+++ b/aiofastnet/api_create_unix_server.py
@@ -7,6 +7,7 @@ import stat
 from .api_utils import (
     Server, _logger, _validate_ssl_timeout, _validate_bio_size
 )
+from .ssl_object import aiofn_preflight_server_context
 
 
 class UnixServer(Server):
@@ -47,6 +48,10 @@ async def create_unix_server(
 
     if isinstance(ssl, bool):
         raise TypeError('ssl argument must be an SSLContext or None')
+
+    if ssl is not None:
+        # Surface a clear error at create time (bundled backend); no-op otherwise.
+        aiofn_preflight_server_context(ssl)
 
     ssl_handshake_timeout = _validate_ssl_timeout(
         "ssl_handshake_timeout", ssl_handshake_timeout, ssl)

--- a/aiofastnet/openssl.pxd
+++ b/aiofastnet/openssl.pxd
@@ -38,6 +38,12 @@ cdef extern from "openssl_compat.h":
     ctypedef struct OPENSSL_STACK:
         pass
 
+    ctypedef struct SSL_METHOD:
+        pass
+
+    ctypedef struct X509_STORE:
+        pass
+
     enum:
         SSL_VERIFY_PEER
         SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER
@@ -48,6 +54,34 @@ cdef extern from "openssl_compat.h":
 
     int init_openssl_compat(const char *ssl_lib_path, const char *crypto_lib_path)
     const char* openssl_compat_last_error()
+
+    # Bundled backend (static OpenSSL)
+    int aiofn_bundled_openssl_available()
+    int init_openssl_compat_bundled()
+    int aiofn_bundled_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                                      unsigned int protos_len)
+
+    # SSL_CTX construction (bundled backend only)
+    SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth)
+    const SSL_METHOD *TLS_method()
+    void SSL_CTX_free(SSL_CTX *ctx)
+    void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, void *cb)
+    uint64_t SSL_CTX_set_options(SSL_CTX *ctx, uint64_t op)
+    int aiofn_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version)
+    int aiofn_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version)
+    X509_STORE *SSL_CTX_get_cert_store(const SSL_CTX *ctx)
+    int X509_STORE_add_cert(X509_STORE *store, X509 *x)
+    X509 *d2i_X509(X509 **px, const unsigned char **inp, long length)
+    int SSL_CTX_use_certificate_chain_file(SSL_CTX *ctx, const char *file)
+    int SSL_CTX_use_PrivateKey_file(SSL_CTX *ctx, const char *file, int type)
+    int SSL_CTX_check_private_key(const SSL_CTX *ctx)
+    int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str)
+    int SSL_CTX_set_alpn_protos(SSL_CTX *ctx, const unsigned char *protos,
+                                unsigned int protos_len)
+    int SSL_CTX_load_verify_locations(SSL_CTX *ctx, const char *cafile,
+                                      const char *capath)
+    int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param, unsigned long flags)
+    X509 *SSL_CTX_get0_certificate(const SSL_CTX *ctx)
 
     int BIO_free(BIO *a)
     int BIO_pending(BIO *b)

--- a/aiofastnet/openssl_bundled.c
+++ b/aiofastnet/openssl_bundled.c
@@ -1,0 +1,227 @@
+/*
+ * Bundled OpenSSL backend.
+ *
+ * This translation unit is compiled into aiofastnet ONLY when it is built with a
+ * statically linked OpenSSL (setup.py with AIOFASTNET_BUNDLED_OPENSSL=1). Unlike
+ * the borrow backend -- which dlopen()s the interpreter's libssl and resolves the
+ * aiofn_* pointers at runtime (openssl_compat.c) -- here we bind every aiofn_*
+ * pointer directly to the statically linked OpenSSL symbol.
+ *
+ * It is the only place that includes the real OpenSSL headers, so it defines
+ * AIOFASTNET_USE_REAL_OPENSSL_HEADERS before including openssl_compat.h. That
+ * suppresses the opaque-type shims and the function-rename macros, leaving the
+ * real OpenSSL declarations and the extern aiofn_* pointer declarations visible.
+ */
+
+#define AIOFASTNET_USE_REAL_OPENSSL_HEADERS 1
+#include "openssl_compat.h"
+
+#include <string.h>
+
+/* Assign a typed aiofn_* function pointer to a real OpenSSL symbol without
+ * tripping function-pointer type-compatibility warnings (const-ness, STACK_OF
+ * specializations, ossl_ssize_t, etc.). The ABIs are identical by construction. */
+#define BIND(ptr, sym) do { *(void **)(&(ptr)) = (void *)(sym); } while (0)
+
+/* Server-side ALPN: OpenSSL only stores a selection callback, so we keep a copy
+ * of the wire-format protocol list and let SSL_select_next_proto do the matching.
+ * One small allocation per server SSL_CTX; freed for the process lifetime only
+ * (contexts are few and long-lived). */
+typedef struct {
+    unsigned char *protos;
+    unsigned int protos_len;
+} aiofn_alpn_list;
+
+/* The server ALPN list is owned by the SSL_CTX via ex_data, so it is freed
+ * automatically when the SSL_CTX is freed (including on cache rebuild). The
+ * index is allocated once during init_openssl_compat_bundled(). */
+static int g_alpn_ex_idx = -1;
+
+static void aiofn_alpn_free(aiofn_alpn_list *list) {
+    if (list == NULL) {
+        return;
+    }
+    OPENSSL_free(list->protos);
+    OPENSSL_free(list);
+}
+
+static void aiofn_alpn_ex_free_cb(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+                                  int idx, long argl, void *argp) {
+    (void)parent;
+    (void)ad;
+    (void)idx;
+    (void)argl;
+    (void)argp;
+    aiofn_alpn_free((aiofn_alpn_list *)ptr);
+}
+
+static int aiofn_alpn_select_cb(SSL *ssl,
+                                const unsigned char **out, unsigned char *outlen,
+                                const unsigned char *in, unsigned int inlen,
+                                void *arg) {
+    aiofn_alpn_list *list = (aiofn_alpn_list *)arg;
+    (void)ssl;
+
+    if (list == NULL || list->protos == NULL) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+
+    if (SSL_select_next_proto((unsigned char **)out, outlen,
+                              list->protos, list->protos_len,
+                              in, inlen) != OPENSSL_NPN_NEGOTIATED) {
+        return SSL_TLSEXT_ERR_NOACK;
+    }
+    return SSL_TLSEXT_ERR_OK;
+}
+
+int aiofn_bundled_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                                  unsigned int protos_len) {
+    aiofn_alpn_list *list;
+
+    if (g_alpn_ex_idx < 0) {
+        return 0;
+    }
+
+    list = (aiofn_alpn_list *)OPENSSL_malloc(sizeof(*list));
+    if (list == NULL) {
+        return 0;
+    }
+    list->protos = (unsigned char *)OPENSSL_malloc(protos_len);
+    if (list->protos == NULL) {
+        OPENSSL_free(list);
+        return 0;
+    }
+    memcpy(list->protos, protos, protos_len);
+    list->protos_len = protos_len;
+
+    /* Free any list previously attached to this ctx, then hand ownership to the
+     * ctx so it is released by SSL_CTX_free via aiofn_alpn_ex_free_cb. */
+    aiofn_alpn_free((aiofn_alpn_list *)SSL_CTX_get_ex_data(ctx, g_alpn_ex_idx));
+    if (SSL_CTX_set_ex_data(ctx, g_alpn_ex_idx, list) != 1) {
+        aiofn_alpn_free(list);
+        return 0;
+    }
+    SSL_CTX_set_alpn_select_cb(ctx, aiofn_alpn_select_cb, list);
+    return 1;
+}
+
+int aiofn_bundled_openssl_available(void) {
+    return 1;
+}
+
+int init_openssl_compat_bundled(void) {
+    if (OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS |
+                         OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL) != 1) {
+        return 0;
+    }
+
+    if (g_alpn_ex_idx < 0) {
+        g_alpn_ex_idx = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL,
+                                                 aiofn_alpn_ex_free_cb);
+        if (g_alpn_ex_idx < 0) {
+            return 0;
+        }
+    }
+
+    BIND(aiofn_BIO_new, BIO_new);
+    BIND(aiofn_BIO_free, BIO_free);
+    BIND(aiofn_BIO_ctrl, BIO_ctrl);
+    BIND(aiofn_BIO_set_flags, BIO_set_flags);
+    BIND(aiofn_BIO_clear_flags, BIO_clear_flags);
+    BIND(aiofn_BIO_set_data, BIO_set_data);
+    BIND(aiofn_BIO_get_data, BIO_get_data);
+    BIND(aiofn_BIO_set_init, BIO_set_init);
+    BIND(aiofn_BIO_set_shutdown, BIO_set_shutdown);
+
+    BIND(aiofn_BIO_meth_new, BIO_meth_new);
+    BIND(aiofn_BIO_meth_set_write, BIO_meth_set_write);
+    BIND(aiofn_BIO_meth_set_read, BIO_meth_set_read);
+    BIND(aiofn_BIO_meth_set_puts, BIO_meth_set_puts);
+    BIND(aiofn_BIO_meth_set_gets, BIO_meth_set_gets);
+    BIND(aiofn_BIO_meth_set_ctrl, BIO_meth_set_ctrl);
+    BIND(aiofn_BIO_meth_set_create, BIO_meth_set_create);
+    BIND(aiofn_BIO_meth_set_destroy, BIO_meth_set_destroy);
+    BIND(aiofn_BIO_meth_free, BIO_meth_free);
+
+    BIND(aiofn_SSL_new, SSL_new);
+    BIND(aiofn_SSL_free, SSL_free);
+    BIND(aiofn_SSL_set_bio, SSL_set_bio);
+    BIND(aiofn_SSL_set_fd, SSL_set_fd);
+    BIND(aiofn_SSL_get_rbio, SSL_get_rbio);
+    BIND(aiofn_SSL_get_wbio, SSL_get_wbio);
+    BIND(aiofn_SSL_set_accept_state, SSL_set_accept_state);
+    BIND(aiofn_SSL_set_connect_state, SSL_set_connect_state);
+    BIND(aiofn_SSL_ctrl, SSL_ctrl);
+    BIND(aiofn_SSL_clear_options, SSL_clear_options);
+    BIND(aiofn_SSL_set_options_sym, SSL_set_options);
+    BIND(aiofn_SSL_get_error, SSL_get_error);
+    BIND(aiofn_SSL_pending, SSL_pending);
+    BIND(aiofn_SSL_renegotiate, SSL_renegotiate);
+    BIND(aiofn_SSL_do_handshake, SSL_do_handshake);
+    BIND(aiofn_SSL_read, SSL_read);
+    BIND(aiofn_SSL_write, SSL_write);
+    BIND(aiofn_SSL_sendfile, SSL_sendfile);
+    BIND(aiofn_SSL_shutdown, SSL_shutdown);
+    BIND(aiofn_SSL_get_verify_result, SSL_get_verify_result);
+    BIND(aiofn_SSL_get_version, SSL_get_version);
+    BIND(aiofn_SSL_get_finished, SSL_get_finished);
+    BIND(aiofn_SSL_get_peer_finished, SSL_get_peer_finished);
+    BIND(aiofn_SSL_session_reused, SSL_session_reused);
+    BIND(aiofn_SSL_get_peer_cert_chain, SSL_get_peer_cert_chain);
+    BIND(aiofn_SSL_get0_verified_chain, SSL_get0_verified_chain);
+    BIND(aiofn_SSL_get_ciphers, SSL_get_ciphers);
+    BIND(aiofn_SSL_get_client_ciphers, SSL_get_client_ciphers);
+    BIND(aiofn_SSL_get_peer_certificate, SSL_get1_peer_certificate);
+    BIND(aiofn_SSL_get0_alpn_selected, SSL_get0_alpn_selected);
+    BIND(aiofn_SSL_set_read_ahead, SSL_set_read_ahead);
+
+    BIND(aiofn_SSL_get_current_cipher, SSL_get_current_cipher);
+    BIND(aiofn_SSL_CIPHER_get_name, SSL_CIPHER_get_name);
+    BIND(aiofn_SSL_CIPHER_get_version, SSL_CIPHER_get_version);
+    BIND(aiofn_SSL_CIPHER_get_bits, SSL_CIPHER_get_bits);
+
+    BIND(aiofn_SSL_get0_param, SSL_get0_param);
+    BIND(aiofn_SSL_CTX_get0_param, SSL_CTX_get0_param);
+    BIND(aiofn_X509_VERIFY_PARAM_get_hostflags, X509_VERIFY_PARAM_get_hostflags);
+    BIND(aiofn_X509_VERIFY_PARAM_set_hostflags, X509_VERIFY_PARAM_set_hostflags);
+    BIND(aiofn_X509_VERIFY_PARAM_set1_host, X509_VERIFY_PARAM_set1_host);
+    BIND(aiofn_X509_VERIFY_PARAM_set1_ip, X509_VERIFY_PARAM_set1_ip);
+
+    BIND(aiofn_X509_verify_cert_error_string, X509_verify_cert_error_string);
+    BIND(aiofn_X509_free, X509_free);
+    BIND(aiofn_i2d_X509, i2d_X509);
+    BIND(aiofn_OPENSSL_sk_num, OPENSSL_sk_num);
+    BIND(aiofn_OPENSSL_sk_value, OPENSSL_sk_value);
+
+    BIND(aiofn_ERR_peek_last_error, ERR_peek_last_error);
+    BIND(aiofn_ERR_clear_error, ERR_clear_error);
+    BIND(aiofn_ERR_lib_error_string, ERR_lib_error_string);
+    BIND(aiofn_ERR_reason_error_string, ERR_reason_error_string);
+    BIND(aiofn_ERR_print_errors_cb, ERR_print_errors_cb);
+
+    BIND(aiofn_ASN1_OCTET_STRING_free, ASN1_OCTET_STRING_free);
+    BIND(aiofn_ASN1_STRING_get0_data, ASN1_STRING_get0_data);
+    BIND(aiofn_ASN1_STRING_length, ASN1_STRING_length);
+    BIND(aiofn_a2i_IPADDRESS, a2i_IPADDRESS);
+
+    /* SSL_CTX builder symbols (used only by the bundled backend). */
+    BIND(aiofn_SSL_CTX_new, SSL_CTX_new);
+    BIND(aiofn_TLS_method, TLS_method);
+    BIND(aiofn_SSL_CTX_free, SSL_CTX_free);
+    BIND(aiofn_SSL_CTX_ctrl, SSL_CTX_ctrl);
+    BIND(aiofn_SSL_CTX_set_verify, SSL_CTX_set_verify);
+    BIND(aiofn_SSL_CTX_set_options, SSL_CTX_set_options);
+    BIND(aiofn_SSL_CTX_get_cert_store, SSL_CTX_get_cert_store);
+    BIND(aiofn_X509_STORE_add_cert, X509_STORE_add_cert);
+    BIND(aiofn_d2i_X509, d2i_X509);
+    BIND(aiofn_SSL_CTX_use_certificate_chain_file, SSL_CTX_use_certificate_chain_file);
+    BIND(aiofn_SSL_CTX_use_PrivateKey_file, SSL_CTX_use_PrivateKey_file);
+    BIND(aiofn_SSL_CTX_check_private_key, SSL_CTX_check_private_key);
+    BIND(aiofn_SSL_CTX_set_cipher_list, SSL_CTX_set_cipher_list);
+    BIND(aiofn_SSL_CTX_set_alpn_protos, SSL_CTX_set_alpn_protos);
+    BIND(aiofn_SSL_CTX_load_verify_locations, SSL_CTX_load_verify_locations);
+    BIND(aiofn_X509_VERIFY_PARAM_set_flags, X509_VERIFY_PARAM_set_flags);
+    BIND(aiofn_SSL_CTX_get0_certificate, SSL_CTX_get0_certificate);
+
+    return 1;
+}

--- a/aiofastnet/openssl_compat.c
+++ b/aiofastnet/openssl_compat.c
@@ -93,6 +93,29 @@ const unsigned char *(*aiofn_ASN1_STRING_get0_data)(const ASN1_OCTET_STRING *x) 
 int (*aiofn_ASN1_STRING_length)(ASN1_OCTET_STRING *x) = NULL;
 ASN1_OCTET_STRING *(*aiofn_a2i_IPADDRESS)(const char *ipasc) = NULL;
 
+/* Bundled-backend SSL_CTX builder pointers (bound by init_openssl_compat_bundled;
+ * left NULL and unused on the borrow backend). */
+SSL_CTX *(*aiofn_SSL_CTX_new)(const SSL_METHOD *meth) = NULL;
+const SSL_METHOD *(*aiofn_TLS_method)(void) = NULL;
+void (*aiofn_SSL_CTX_free)(SSL_CTX *ctx) = NULL;
+long (*aiofn_SSL_CTX_ctrl)(SSL_CTX *ctx, int cmd, long larg, void *parg) = NULL;
+void (*aiofn_SSL_CTX_set_verify)(SSL_CTX *ctx, int mode, void *cb) = NULL;
+uint64_t (*aiofn_SSL_CTX_set_options)(SSL_CTX *ctx, uint64_t op) = NULL;
+X509_STORE *(*aiofn_SSL_CTX_get_cert_store)(const SSL_CTX *ctx) = NULL;
+int (*aiofn_X509_STORE_add_cert)(X509_STORE *store, X509 *x) = NULL;
+X509 *(*aiofn_d2i_X509)(X509 **px, const unsigned char **in, long len) = NULL;
+int (*aiofn_SSL_CTX_use_certificate_chain_file)(SSL_CTX *ctx, const char *file) = NULL;
+int (*aiofn_SSL_CTX_use_PrivateKey_file)(SSL_CTX *ctx, const char *file, int type) = NULL;
+int (*aiofn_SSL_CTX_check_private_key)(const SSL_CTX *ctx) = NULL;
+int (*aiofn_SSL_CTX_set_cipher_list)(SSL_CTX *ctx, const char *str) = NULL;
+int (*aiofn_SSL_CTX_set_alpn_protos)(SSL_CTX *ctx, const unsigned char *protos,
+                                     unsigned int protos_len) = NULL;
+int (*aiofn_SSL_CTX_load_verify_locations)(SSL_CTX *ctx, const char *cafile,
+                                           const char *capath) = NULL;
+int (*aiofn_X509_VERIFY_PARAM_set_flags)(X509_VERIFY_PARAM *param,
+                                         unsigned long flags) = NULL;
+X509 *(*aiofn_SSL_CTX_get0_certificate)(const SSL_CTX *ctx) = NULL;
+
 static const char *g_last_error = NULL;
 static char g_last_error_buf[1024];
 
@@ -423,6 +446,38 @@ int aiofn_BIO_get_ktls_recv(BIO *b) {
 int aiofn_ERR_GET_LIB(unsigned long e) {
     return (int)((e >> 23) & 0xFFUL);
 }
+
+/* SSL_CTX_set_min/max_proto_version are ctrl macros in OpenSSL; wrap them so the
+ * bundled backend can call them through the aiofn_SSL_CTX_ctrl pointer.
+ * SSL_CTRL_SET_MIN_PROTO_VERSION == 123, SSL_CTRL_SET_MAX_PROTO_VERSION == 124. */
+int aiofn_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version) {
+    return (int)aiofn_SSL_CTX_ctrl(ctx, 123, version, NULL);
+}
+
+int aiofn_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version) {
+    return (int)aiofn_SSL_CTX_ctrl(ctx, 124, version, NULL);
+}
+
+#ifndef AIOFASTNET_BUNDLED_OPENSSL
+/* Stubs used when aiofastnet is built without a statically linked OpenSSL.
+ * The real implementations live in openssl_bundled.c. */
+int aiofn_bundled_openssl_available(void) {
+    return 0;
+}
+
+int init_openssl_compat_bundled(void) {
+    set_last_error("aiofastnet was built without bundled OpenSSL support");
+    return 0;
+}
+
+int aiofn_bundled_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                                  unsigned int protos_len) {
+    (void)ctx;
+    (void)protos;
+    (void)protos_len;
+    return 0;
+}
+#endif /* AIOFASTNET_BUNDLED_OPENSSL */
 
 const char *openssl_compat_last_error(void) {
     return g_last_error;

--- a/aiofastnet/openssl_compat.h
+++ b/aiofastnet/openssl_compat.h
@@ -22,6 +22,18 @@ extern "C" {
 //#define SSL_ERROR_SYSCALL 5
 //#define SSL_ERROR_ZERO_RETURN 6
 
+#ifdef AIOFASTNET_USE_REAL_OPENSSL_HEADERS
+/* Bundled backend: pull in the real OpenSSL headers so this translation unit can
+ * bind the aiofn_* pointers directly to the statically linked OpenSSL symbols.
+ * The opaque-type/constant shims and the function-rename macros below are skipped
+ * in this mode so the real OpenSSL declarations stay usable. */
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <openssl/crypto.h>
+#else
 /* Opaque OpenSSL types */
 typedef struct ssl_ctx_st SSL_CTX;
 typedef struct ssl_st SSL;
@@ -32,15 +44,8 @@ typedef struct x509_st X509;
 typedef struct X509_VERIFY_PARAM_st X509_VERIFY_PARAM;
 typedef struct asn1_string_st ASN1_OCTET_STRING;
 typedef struct stack_st OPENSSL_STACK;
-
-typedef int (*bio_write_fn)(BIO *, const char *, int);
-typedef int (*bio_read_fn)(BIO *, char *, int);
-typedef int (*bio_puts_fn)(BIO *, const char *);
-typedef int (*bio_gets_fn)(BIO *, char *, int);
-typedef long (*bio_ctrl_fn)(BIO *, int, long, void *);
-typedef int (*bio_create_fn)(BIO *);
-typedef int (*bio_destroy_fn)(BIO *);
-typedef int (*err_print_errors_cb_fn)(const char *str, size_t len, void *u);
+typedef struct ssl_method_st SSL_METHOD;
+typedef struct x509_store_st X509_STORE;
 
 #define SSL_VERIFY_PEER 0x01
 
@@ -74,9 +79,27 @@ typedef int (*err_print_errors_cb_fn)(const char *str, size_t len, void *u);
 #define BIO_FLAGS_WRITE 0x02
 #define BIO_FLAGS_RWS 0x07
 #define BIO_FLAGS_SHOULD_RETRY 0x08
+#endif /* AIOFASTNET_USE_REAL_OPENSSL_HEADERS */
+
+/* Callback typedefs for the static-mem BIO_METHOD shim; needed in both modes. */
+typedef int (*bio_write_fn)(BIO *, const char *, int);
+typedef int (*bio_read_fn)(BIO *, char *, int);
+typedef int (*bio_puts_fn)(BIO *, const char *);
+typedef int (*bio_gets_fn)(BIO *, char *, int);
+typedef long (*bio_ctrl_fn)(BIO *, int, long, void *);
+typedef int (*bio_create_fn)(BIO *);
+typedef int (*bio_destroy_fn)(BIO *);
+typedef int (*err_print_errors_cb_fn)(const char *str, size_t len, void *u);
 
 int init_openssl_compat(const char *ssl_lib_path, const char *crypto_lib_path);
 const char *openssl_compat_last_error(void);
+
+/* Bundled backend (static OpenSSL) entry points. When aiofastnet is built
+ * without bundled OpenSSL these are stubbed in openssl_compat.c. */
+int aiofn_bundled_openssl_available(void);
+int init_openssl_compat_bundled(void);
+int aiofn_bundled_set_server_alpn(SSL_CTX *ctx, const unsigned char *protos,
+                                  unsigned int protos_len);
 
 /* Global function pointers */
 
@@ -166,6 +189,32 @@ extern const unsigned char *(*aiofn_ASN1_STRING_get0_data)(const ASN1_OCTET_STRI
 extern int (*aiofn_ASN1_STRING_length)(ASN1_OCTET_STRING *x);
 extern ASN1_OCTET_STRING *(*aiofn_a2i_IPADDRESS)(const char *ipasc);
 
+/* Function pointers used only by the bundled backend to build its own SSL_CTX. */
+extern SSL_CTX *(*aiofn_SSL_CTX_new)(const SSL_METHOD *meth);
+extern const SSL_METHOD *(*aiofn_TLS_method)(void);
+extern void (*aiofn_SSL_CTX_free)(SSL_CTX *ctx);
+extern long (*aiofn_SSL_CTX_ctrl)(SSL_CTX *ctx, int cmd, long larg, void *parg);
+extern void (*aiofn_SSL_CTX_set_verify)(SSL_CTX *ctx, int mode, void *cb);
+extern uint64_t (*aiofn_SSL_CTX_set_options)(SSL_CTX *ctx, uint64_t op);
+extern X509_STORE *(*aiofn_SSL_CTX_get_cert_store)(const SSL_CTX *ctx);
+extern int (*aiofn_X509_STORE_add_cert)(X509_STORE *store, X509 *x);
+extern X509 *(*aiofn_d2i_X509)(X509 **px, const unsigned char **in, long len);
+extern int (*aiofn_SSL_CTX_use_certificate_chain_file)(SSL_CTX *ctx, const char *file);
+extern int (*aiofn_SSL_CTX_use_PrivateKey_file)(SSL_CTX *ctx, const char *file, int type);
+extern int (*aiofn_SSL_CTX_check_private_key)(const SSL_CTX *ctx);
+extern int (*aiofn_SSL_CTX_set_cipher_list)(SSL_CTX *ctx, const char *str);
+extern int (*aiofn_SSL_CTX_set_alpn_protos)(SSL_CTX *ctx, const unsigned char *protos,
+                                            unsigned int protos_len);
+extern int (*aiofn_SSL_CTX_load_verify_locations)(SSL_CTX *ctx, const char *cafile,
+                                                  const char *capath);
+extern int (*aiofn_X509_VERIFY_PARAM_set_flags)(X509_VERIFY_PARAM *param,
+                                                unsigned long flags);
+extern X509 *(*aiofn_SSL_CTX_get0_certificate)(const SSL_CTX *ctx);
+
+/* Helpers wrapping ctrl-macro APIs (implemented in openssl_compat.c). */
+int aiofn_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version);
+int aiofn_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version);
+
 /* Macro-based APIs */
 int aiofn_BIO_pending(BIO *b);
 long aiofn_BIO_get_mem_data(BIO *b, char **pp);
@@ -175,6 +224,7 @@ int aiofn_BIO_get_ktls_send(BIO *b);
 int aiofn_BIO_get_ktls_recv(BIO *b);
 int aiofn_ERR_GET_LIB(unsigned long e);
 
+#ifndef AIOFASTNET_USE_REAL_OPENSSL_HEADERS
 #define BIO_new aiofn_BIO_new
 #define BIO_free aiofn_BIO_free
 #define BIO_ctrl aiofn_BIO_ctrl
@@ -261,6 +311,25 @@ int aiofn_ERR_GET_LIB(unsigned long e);
 #define ASN1_STRING_get0_data aiofn_ASN1_STRING_get0_data
 #define ASN1_STRING_length aiofn_ASN1_STRING_length
 #define a2i_IPADDRESS aiofn_a2i_IPADDRESS
+
+#define SSL_CTX_new aiofn_SSL_CTX_new
+#define TLS_method aiofn_TLS_method
+#define SSL_CTX_free aiofn_SSL_CTX_free
+#define SSL_CTX_ctrl aiofn_SSL_CTX_ctrl
+#define SSL_CTX_set_verify aiofn_SSL_CTX_set_verify
+#define SSL_CTX_set_options aiofn_SSL_CTX_set_options
+#define SSL_CTX_get_cert_store aiofn_SSL_CTX_get_cert_store
+#define X509_STORE_add_cert aiofn_X509_STORE_add_cert
+#define d2i_X509 aiofn_d2i_X509
+#define SSL_CTX_use_certificate_chain_file aiofn_SSL_CTX_use_certificate_chain_file
+#define SSL_CTX_use_PrivateKey_file aiofn_SSL_CTX_use_PrivateKey_file
+#define SSL_CTX_check_private_key aiofn_SSL_CTX_check_private_key
+#define SSL_CTX_set_cipher_list aiofn_SSL_CTX_set_cipher_list
+#define SSL_CTX_set_alpn_protos aiofn_SSL_CTX_set_alpn_protos
+#define SSL_CTX_load_verify_locations aiofn_SSL_CTX_load_verify_locations
+#define X509_VERIFY_PARAM_set_flags aiofn_X509_VERIFY_PARAM_set_flags
+#define SSL_CTX_get0_certificate aiofn_SSL_CTX_get0_certificate
+#endif /* AIOFASTNET_USE_REAL_OPENSSL_HEADERS */
 
 #ifdef __cplusplus
 }

--- a/aiofastnet/openssl_compat.py
+++ b/aiofastnet/openssl_compat.py
@@ -4,15 +4,6 @@ from dataclasses import dataclass
 
 import _ssl
 
-_ssl_module_path = getattr(_ssl, '__file__', None)
-if _ssl_module_path is None:
-    raise ImportError(
-        "aiofastnet requires Python distribution that is dynamically "
-        "linked against OpenSSL. It seems your Python is linked "
-        "statically against OpenSSL (this is common for uv virtual "
-        "envs)"
-    )
-
 
 @dataclass(frozen=True)
 class OpenSSLDynLibs:
@@ -36,21 +27,41 @@ else:
     raise ImportError(f"unsupported platform {os.name}")
 
 
-def _find_openssl_library_paths() -> OpenSSLDynLibs:
-    try:
-        openssl_library_paths = aiofn_get_openssl_library_paths(
-            _ssl_module_path)
-    except OSError as exc:
-        raise ImportError(
-            "aiofastnet could not identify the OpenSSL dynamic libraries "
-            "used by Python's _ssl module"
-        ) from exc
+def find_openssl_library_paths():
+    """Discover the libssl/libcrypto that Python's ``_ssl`` is dynamically linked
+    against, so aiofastnet can reuse the interpreter's OpenSSL (the *borrow*
+    backend).
 
-    libssl_path, libcrypto_path = openssl_library_paths
+    Returns an :class:`OpenSSLDynLibs`, or ``None`` when the interpreter's
+    OpenSSL cannot be borrowed -- e.g. ``_ssl`` is statically linked / has no
+    discoverable shared libssl, as is the case for uv's python-build-standalone
+    distributions. In that case aiofastnet falls back to its own bundled,
+    statically linked OpenSSL (when the extension was compiled with it).
+    """
+    ssl_module_path = getattr(_ssl, "__file__", None)
+    if ssl_module_path is None:
+        # _ssl is a builtin (statically linked into the interpreter); there is no
+        # separate libssl to discover.
+        return None
+    try:
+        libssl_path, libcrypto_path = aiofn_get_openssl_library_paths(
+            ssl_module_path)
+    except OSError:
+        return None
     return OpenSSLDynLibs(libssl_path, libcrypto_path)
 
 
-OPENSSL_DYN_LIBS = _find_openssl_library_paths()
+# Resolved once at import. ``None`` when the interpreter's OpenSSL cannot be
+# borrowed (the bundled backend, if compiled in, is used instead). The actual
+# borrow-vs-bundled decision is made in ssl_object.pyx, which can query the
+# compiled-in bundled availability.
+BORROW_LIBS = find_openssl_library_paths()
+
+# Public, always-valid descriptor. On the bundled backend we expose a
+# descriptive placeholder so logging and ``aiofastnet.OPENSSL_DYN_LIBS`` keep
+# working.
+OPENSSL_DYN_LIBS = BORROW_LIBS if BORROW_LIBS is not None else OpenSSLDynLibs(
+    "<bundled-static-openssl>", "<bundled-static-openssl>")
 
 
 def create_transport_context(server_side, server_hostname):

--- a/aiofastnet/ssl_object.pyx
+++ b/aiofastnet/ssl_object.pyx
@@ -83,8 +83,36 @@ from .openssl cimport (
     i2d_X509,
     init_openssl_compat,
     openssl_compat_last_error,
+    SSL_METHOD,
+    X509_STORE,
+    aiofn_bundled_openssl_available,
+    init_openssl_compat_bundled,
+    aiofn_bundled_set_server_alpn,
+    SSL_CTX_new,
+    TLS_method,
+    SSL_CTX_free,
+    SSL_CTX_set_verify,
+    SSL_CTX_set_options,
+    aiofn_SSL_CTX_set_min_proto_version,
+    aiofn_SSL_CTX_set_max_proto_version,
+    SSL_CTX_get_cert_store,
+    X509_STORE_add_cert,
+    d2i_X509,
+    SSL_CTX_use_certificate_chain_file,
+    SSL_CTX_use_PrivateKey_file,
+    SSL_CTX_check_private_key,
+    SSL_CTX_set_cipher_list,
+    SSL_CTX_set_alpn_protos,
+    SSL_CTX_load_verify_locations,
+    X509_VERIFY_PARAM_set_flags,
+    SSL_CTX_get0_certificate,
 )
-from .openssl_compat import OPENSSL_DYN_LIBS
+from cpython.pycapsule cimport (
+    PyCapsule_New,
+    PyCapsule_GetPointer,
+    PyCapsule_IsValid,
+)
+from .openssl_compat import OPENSSL_DYN_LIBS, BORROW_LIBS
 
 from cpython.object cimport PyObject
 from cpython.bytes cimport PyBytes_FromStringAndSize, PyBytes_AS_STRING
@@ -149,15 +177,45 @@ def _ktls_prerequisites_available() -> bool:
     return True
 
 
+# Selected OpenSSL backend. "borrow" reuses the interpreter's OpenSSL (the
+# SSL_CTX is shared from the Python ssl.SSLContext); "bundled" uses aiofastnet's
+# own statically linked OpenSSL and builds its own SSL_CTX.
+BACKEND = None
+cdef bint _BACKEND_BUNDLED = False
+
+
 cdef _init_openssl():
-    if init_openssl_compat(OPENSSL_DYN_LIBS.libssl_path, OPENSSL_DYN_LIBS.libcrypto_path) != 1:
-        missing_lib = openssl_compat_last_error()
-        if missing_lib != NULL:
+    global BACKEND, _BACKEND_BUNDLED
+
+    if BORROW_LIBS is not None:
+        if init_openssl_compat(OPENSSL_DYN_LIBS.libssl_path, OPENSSL_DYN_LIBS.libcrypto_path) != 1:
+            missing_lib = openssl_compat_last_error()
+            if missing_lib != NULL:
+                raise ImportError(
+                    f"aiofastnet: failed to initialize OpenSSL compatibility layer; "
+                    f"missing symbol: {PyUnicode_FromString(missing_lib)}; "
+                    f"ssl_lib={OPENSSL_DYN_LIBS.libssl}, crypto_lib={OPENSSL_DYN_LIBS.libcrypto}")
+            raise ImportError("aiofastnet: failed to initialize OpenSSL compatibility layer")
+        BACKEND = "borrow"
+        return
+
+    if aiofn_bundled_openssl_available():
+        if init_openssl_compat_bundled() != 1:
+            missing_lib = openssl_compat_last_error()
+            detail = (f"; {PyUnicode_FromString(missing_lib)}"
+                      if missing_lib != NULL else "")
             raise ImportError(
-                f"aiofastnet: failed to initialize OpenSSL compatibility layer; "
-                f"missing symbol: {PyUnicode_FromString(missing_lib)}; "
-                f"ssl_lib={OPENSSL_DYN_LIBS.libssl}, crypto_lib={OPENSSL_DYN_LIBS.libcrypto}")
-        raise ImportError("aiofastnet: failed to initialize OpenSSL compatibility layer")
+                f"aiofastnet: failed to initialize bundled OpenSSL backend{detail}")
+        BACKEND = "bundled"
+        _BACKEND_BUNDLED = True
+        return
+
+    raise ImportError(
+        "aiofastnet requires a Python distribution that is dynamically linked "
+        "against OpenSSL. Your Python appears to be statically linked against "
+        "OpenSSL (common for uv's python-build-standalone), and this aiofastnet "
+        "build does not include a bundled OpenSSL. Either use a dynamically "
+        "linked Python, or install an aiofastnet build with bundled OpenSSL.")
 
 
 _init_openssl()
@@ -185,6 +243,279 @@ cdef SSL_CTX* _get_ssl_ctx_ptr(object py_ctx) except NULL:
     # The guys from python are reluctant to expose it directly:
     # https://bugs.python.org/issue43902
     return (<PySSLContextHack*> <PyObject*> py_ctx).ctx
+
+
+# ---------------------------------------------------------------------------
+# Bundled backend: build our own SSL_CTX from the caller's ssl.SSLContext.
+#
+# Used only when aiofastnet runs on its statically linked OpenSSL (e.g. uv
+# python-build-standalone), where the interpreter's OpenSSL SSL_CTX cannot be
+# borrowed. The built SSL_CTX is cached on the Python context inside a PyCapsule
+# whose destructor frees it, so it is reused across connections.
+# ---------------------------------------------------------------------------
+
+cdef bytes _CAP_NAME_B = b"aiofastnet.bundled_ssl_ctx"
+cdef const char* _CAP_NAME = _CAP_NAME_B
+
+
+cdef void _bundled_ctx_capsule_destructor(object cap) noexcept:
+    if not PyCapsule_IsValid(cap, _CAP_NAME):
+        return
+    cdef void* p = PyCapsule_GetPointer(cap, _CAP_NAME)
+    if p != NULL:
+        SSL_CTX_free(<SSL_CTX*>p)
+
+
+cdef _bundled_ssl_error(str descr):
+    cdef unsigned long e = ERR_peek_last_error()
+    cdef const char* reason = ERR_reason_error_string(e) if e != 0 else NULL
+    msg = PyUnicode_FromString(reason) if reason != NULL else ""
+    ERR_clear_error()
+    return ssl.SSLError(f"aiofastnet bundled backend: {descr}: {msg}")
+
+
+cdef int _tls_version_to_openssl(object v):
+    # ssl.TLSVersion enum values match OpenSSL version constants; the negative
+    # MINIMUM_SUPPORTED / MAXIMUM_SUPPORTED sentinels map to 0 ("auto").
+    cdef long iv = int(v)
+    if iv < 0:
+        return 0
+    return <int>iv
+
+
+cdef int _verify_mode_to_openssl(object verify_mode):
+    # ssl.VerifyMode (CERT_NONE=0, CERT_OPTIONAL=1, CERT_REQUIRED=2) is NOT the
+    # same as OpenSSL's SSL_VERIFY_* bit flags. Map it the way CPython's ssl
+    # module does, otherwise the server never sends a CertificateRequest
+    # (SSL_VERIFY_PEER is required) and the client never aborts on a bad cert.
+    # SSL_VERIFY_NONE=0, SSL_VERIFY_PEER=0x01, SSL_VERIFY_FAIL_IF_NO_PEER_CERT=0x02
+    cdef int vm = int(verify_mode)
+    if vm == 0:        # CERT_NONE
+        return 0
+    elif vm == 1:      # CERT_OPTIONAL
+        return 0x01
+    else:              # CERT_REQUIRED
+        return 0x01 | 0x02
+
+
+cdef bytes _encode_alpn(object protocols):
+    cdef bytearray buf = bytearray()
+    cdef bytes b
+    for proto in protocols:
+        b = proto.encode("ascii") if isinstance(proto, str) else bytes(proto)
+        if len(b) == 0 or len(b) > 255:
+            raise ValueError(f"invalid ALPN protocol: {proto!r}")
+        buf.append(len(b))
+        buf += b
+    return bytes(buf)
+
+
+cdef _bundled_add_ca_der(SSL_CTX* ctx, bytes der):
+    cdef const unsigned char* p = <const unsigned char*>PyBytes_AS_STRING(der)
+    cdef X509* x = d2i_X509(NULL, &p, <long>len(der))
+    if x == NULL:
+        ERR_clear_error()
+        return
+    cdef X509_STORE* store = SSL_CTX_get_cert_store(ctx)
+    # Duplicate adds return an error we deliberately ignore.
+    X509_STORE_add_cert(store, x)
+    ERR_clear_error()
+    X509_free(x)
+
+
+cdef _bundled_load_verify_locations(SSL_CTX* ctx, tuple args, dict kwargs):
+    cafile = kwargs.get("cafile")
+    capath = kwargs.get("capath")
+    if cafile is None and len(args) >= 1:
+        cafile = args[0]
+    if capath is None and len(args) >= 2:
+        capath = args[1]
+    # cadata is already covered by get_ca_certs() on the Python context.
+
+    cdef bytes caf = os.fsencode(cafile) if cafile is not None else None
+    cdef bytes cap = os.fsencode(capath) if capath is not None else None
+    cdef const char* caf_p = <const char*>caf if caf is not None else NULL
+    cdef const char* cap_p = <const char*>cap if cap is not None else NULL
+    if caf_p == NULL and cap_p == NULL:
+        return
+    if SSL_CTX_load_verify_locations(ctx, caf_p, cap_p) != 1:
+        # May already be present via get_ca_certs(); don't hard-fail.
+        ERR_clear_error()
+
+
+cdef _bundled_load_cert_chain(SSL_CTX* ctx, tuple args, dict kwargs):
+    certfile = kwargs.get("certfile")
+    keyfile = kwargs.get("keyfile")
+    password = kwargs.get("password")
+    if certfile is None and len(args) >= 1:
+        certfile = args[0]
+    if keyfile is None and len(args) >= 2:
+        keyfile = args[1]
+    if password is None and len(args) >= 3:
+        password = args[2]
+
+    if certfile is None:
+        raise ssl.SSLError(
+            "aiofastnet bundled backend: load_cert_chain requires a certfile")
+    if password is not None:
+        raise NotImplementedError(
+            "aiofastnet bundled backend: password-protected private keys are "
+            "not supported yet")
+
+    cdef bytes cf = os.fsencode(certfile)
+    if SSL_CTX_use_certificate_chain_file(ctx, <const char*>cf) != 1:
+        raise _bundled_ssl_error("use_certificate_chain_file failed")
+
+    keypath = keyfile if keyfile is not None else certfile
+    cdef bytes kf = os.fsencode(keypath)
+    # SSL_FILETYPE_PEM == 1
+    if SSL_CTX_use_PrivateKey_file(ctx, <const char*>kf, 1) != 1:
+        raise _bundled_ssl_error("use_PrivateKey_file failed")
+    if SSL_CTX_check_private_key(ctx) != 1:
+        raise _bundled_ssl_error("private key does not match certificate")
+
+
+cdef _bundled_set_ciphers(SSL_CTX* ctx, object cipherlist):
+    cdef bytes cb = cipherlist.encode()
+    if SSL_CTX_set_cipher_list(ctx, <const char*>cb) != 1:
+        raise _bundled_ssl_error("set_cipher_list failed")
+
+
+cdef _bundled_set_alpn(SSL_CTX* ctx, object protocols):
+    cdef bytes wire = _encode_alpn(protocols)
+    cdef const unsigned char* p = <const unsigned char*>PyBytes_AS_STRING(wire)
+    cdef unsigned int wlen = <unsigned int>len(wire)
+    # SSL_CTX_set_alpn_protos returns 0 on success (advertised by clients).
+    if SSL_CTX_set_alpn_protos(ctx, p, wlen) != 0:
+        raise _bundled_ssl_error("SSL_CTX_set_alpn_protos failed")
+    # Server-side selection callback (takes ownership of a copy of the list).
+    if aiofn_bundled_set_server_alpn(ctx, p, wlen) != 1:
+        raise ssl.SSLError(
+            "aiofastnet bundled backend: failed to install server ALPN callback")
+
+
+cdef _bundled_replay(SSL_CTX* ctx, tuple entry):
+    cdef str method = entry[0]
+    cdef tuple args = entry[1]
+    cdef dict kwargs = entry[2]
+    if method == "load_verify_locations":
+        _bundled_load_verify_locations(ctx, args, kwargs)
+    elif method == "load_cert_chain":
+        _bundled_load_cert_chain(ctx, args, kwargs)
+    elif method == "set_ciphers":
+        _bundled_set_ciphers(ctx, args[0])
+    elif method == "set_alpn_protocols":
+        _bundled_set_alpn(ctx, args[0])
+
+
+cdef SSL_CTX* _build_bundled_ctx(object py_ctx) except NULL:
+    cdef SSL_CTX* ctx = SSL_CTX_new(TLS_method())
+    cdef unsigned long vflags
+    if ctx == NULL:
+        raise MemoryError("aiofastnet bundled backend: SSL_CTX_new failed")
+    try:
+        aiofn_SSL_CTX_set_min_proto_version(
+            ctx, _tls_version_to_openssl(py_ctx.minimum_version))
+        aiofn_SSL_CTX_set_max_proto_version(
+            ctx, _tls_version_to_openssl(py_ctx.maximum_version))
+        SSL_CTX_set_options(ctx, <uint64_t>int(py_ctx.options))
+        SSL_CTX_set_verify(ctx, _verify_mode_to_openssl(py_ctx.verify_mode), NULL)
+
+        # Certificate-verification flags (CRL checking, X509_STRICT, ...).
+        # NOTE: other context state that cannot be read back from a plain
+        # ssl.SSLContext -- post_handshake_auth, custom hostflags, sni/verify
+        # callbacks -- is not reproduced by the bundled backend yet.
+        vflags = <unsigned long>int(py_ctx.verify_flags)
+        if vflags:
+            X509_VERIFY_PARAM_set_flags(SSL_CTX_get0_param(ctx), vflags)
+
+        # Trust anchors readable from any SSLContext (covers system CAs loaded by
+        # ssl.create_default_context() and any cadata).
+        for der in py_ctx.get_ca_certs(binary_form=True):
+            _bundled_add_ca_der(ctx, der)
+
+        # Replay config that cannot be read back from a plain SSLContext.
+        config = getattr(py_ctx, "_aiofastnet_config", None)
+        if config:
+            for entry in config:
+                _bundled_replay(ctx, entry)
+        return ctx
+    except:
+        SSL_CTX_free(ctx)
+        raise
+
+
+cdef _bundled_missing_server_cert_error():
+    return ssl.SSLError(
+        "aiofastnet bundled backend: the server SSLContext has no certificate. "
+        "On this Python (statically linked OpenSSL), aiofastnet cannot read a "
+        "certificate loaded into a plain ssl.SSLContext. Create the context with "
+        "aiofastnet.SSLContext(...) and call load_cert_chain() on it so aiofastnet "
+        "can replay it onto its own SSL_CTX.")
+
+
+cdef tuple _bundled_ctx_signature(object py_ctx):
+    # Cheap snapshot of everything that feeds the bundled SSL_CTX, so the cache
+    # is rebuilt when the Python context is mutated after first use.
+    #
+    #  * recorded config only grows by append -> its length detects new
+    #    load_cert_chain / load_verify_locations / set_ciphers /
+    #    set_alpn_protocols calls on an aiofastnet.SSLContext.
+    #  * cert_store_stats() is a cheap C-level count that detects trust-store
+    #    mutations (load_verify_locations / load_default_certs) on a *plain*
+    #    ssl.SSLContext, which are not recorded.
+    config = getattr(py_ctx, "_aiofastnet_config", None)
+    cdef dict stats = py_ctx.cert_store_stats()
+    return (
+        int(py_ctx.verify_mode),
+        bool(py_ctx.check_hostname),
+        int(py_ctx.minimum_version),
+        int(py_ctx.maximum_version),
+        int(py_ctx.options),
+        int(py_ctx.verify_flags),
+        stats.get("x509", 0),
+        stats.get("x509_ca", 0),
+        stats.get("crl", 0),
+        len(config) if config is not None else 0,
+    )
+
+
+def aiofn_preflight_server_context(ssl_context):
+    """Validate a server-side SSLContext at server-creation time.
+
+    On the bundled backend this eagerly builds (and caches) the SSL_CTX and
+    ensures it carries a certificate, so a misconfiguration surfaces as a clear
+    error from create_server()/start_server() instead of an opaque per-connection
+    connection reset. No-op on the borrow backend (where the interpreter's own
+    SSL_CTX is shared and already carries whatever was loaded).
+    """
+    if not _BACKEND_BUNDLED or ssl_context is None:
+        return
+    cap = _ensure_bundled_ctx(ssl_context)
+    cdef SSL_CTX* ctx = <SSL_CTX*>PyCapsule_GetPointer(cap, _CAP_NAME)
+    if SSL_CTX_get0_certificate(ctx) == NULL:
+        raise _bundled_missing_server_cert_error()
+
+
+cdef object _ensure_bundled_ctx(object py_ctx):
+    # Return a PyCapsule that owns the bundled SSL_CTX for py_ctx, (re)building
+    # and caching it on the context whenever its configuration signature changes.
+    sig = _bundled_ctx_signature(py_ctx)
+    cap = getattr(py_ctx, "_aiofastnet_bundled_ctx", None)
+    cached_sig = getattr(py_ctx, "_aiofastnet_bundled_sig", None)
+    if (cap is not None and PyCapsule_IsValid(cap, _CAP_NAME)
+            and cached_sig == sig):
+        return cap
+
+    cdef SSL_CTX* ctx = _build_bundled_ctx(py_ctx)
+    cap = PyCapsule_New(<void*>ctx, _CAP_NAME, _bundled_ctx_capsule_destructor)
+    try:
+        py_ctx._aiofastnet_bundled_ctx = cap
+        py_ctx._aiofastnet_bundled_sig = sig
+    except (AttributeError, TypeError):
+        # Couldn't cache on the context; the SSLObject keeps the capsule alive.
+        pass
+    return cap
 
 
 cdef int _print_error_cb(const char* str, size_t len, void* u) noexcept:
@@ -221,7 +552,20 @@ cdef class SSLObject:
             raise ValueError("SSLContext.check_hostname requires server_hostname")
 
         self.ssl_ctx_py = ssl_context
-        self.ssl_ctx = _get_ssl_ctx_ptr(ssl_context)
+        if _BACKEND_BUNDLED:
+            # Build/reuse our own SSL_CTX from the caller's config. Keep a
+            # reference to the owning capsule so the SSL_CTX outlives this object
+            # even if it could not be cached on the Python context.
+            cap = _ensure_bundled_ctx(ssl_context)
+            self._bundled_ctx_cap = cap
+            self.ssl_ctx = <SSL_CTX*>PyCapsule_GetPointer(cap, _CAP_NAME)
+            if server_side and SSL_CTX_get0_certificate(self.ssl_ctx) == NULL:
+                # Defense in depth: create_server() preflights this, but a server
+                # with no certificate can otherwise only fail deep inside the
+                # handshake with an opaque error.
+                raise _bundled_missing_server_cert_error()
+        else:
+            self.ssl_ctx = _get_ssl_ctx_ptr(ssl_context)
 
         self.ssl = NULL
         self.incoming_buf = None

--- a/scripts/build_openssl.sh
+++ b/scripts/build_openssl.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Build a static, symbol-hidden OpenSSL for bundling into aiofastnet.
+#
+# PoC scope: macOS arm64 (Apple Silicon). Produces libssl.a + libcrypto.a and
+# headers under build/openssl/, which setup.py picks up when
+# AIOFASTNET_BUNDLED_OPENSSL=1 is set.
+#
+# We build with `no-shared` (static only) and `-fvisibility=hidden` so the
+# OpenSSL symbols do not get re-exported from aiofastnet's extension and cannot
+# collide with the interpreter's own (statically embedded) OpenSSL. On macOS the
+# two-level namespace already isolates the copies; hidden visibility is belt-and
+# -suspenders and is what the cryptography wheels rely on cross-platform.
+
+set -euo pipefail
+
+OPENSSL_VERSION="${OPENSSL_VERSION:-3.5.6}"
+OPENSSL_SHA256="${OPENSSL_SHA256:-}"   # optional integrity check, set to verify
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build/openssl-build"
+PREFIX="${REPO_ROOT}/build/openssl"
+
+TARBALL="openssl-${OPENSSL_VERSION}.tar.gz"
+URL="https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/${TARBALL}"
+
+# Pick the OpenSSL Configure target from the host arch (PoC: macOS only).
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64)  TARGET="darwin64-arm64-cc" ;;
+  Darwin-x86_64) TARGET="darwin64-x86_64-cc" ;;
+  *)
+    echo "build_openssl.sh: unsupported host $(uname -s)-$(uname -m) (PoC is macOS-only)" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -f "${PREFIX}/lib/libssl.a" && -f "${PREFIX}/lib/libcrypto.a" ]]; then
+  echo "Static OpenSSL already present at ${PREFIX} -- skipping build."
+  echo "  (delete ${PREFIX} to force a rebuild)"
+  exit 0
+fi
+
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+if [[ ! -f "${TARBALL}" ]]; then
+  echo "Downloading ${URL}"
+  curl -fL --retry 3 -o "${TARBALL}" "${URL}"
+fi
+
+if [[ -n "${OPENSSL_SHA256}" ]]; then
+  echo "${OPENSSL_SHA256}  ${TARBALL}" | shasum -a 256 -c -
+fi
+
+SRC_DIR="${BUILD_DIR}/openssl-${OPENSSL_VERSION}"
+rm -rf "${SRC_DIR}"
+tar xzf "${TARBALL}"
+cd "${SRC_DIR}"
+
+# no-shared:    static archives only
+# no-tests/-docs/-apps trims build time; we only need libssl/libcrypto + headers
+# no-engine/no-legacy keep the surface small (we use standard TLS only)
+./Configure "${TARGET}" \
+  no-shared no-tests no-docs no-apps \
+  no-engine no-legacy \
+  -fvisibility=hidden \
+  --prefix="${PREFIX}" \
+  --openssldir="${PREFIX}/ssl"
+
+make -j"$(sysctl -n hw.ncpu)"
+# install_sw = libraries + headers, skip docs/html
+make install_sw
+
+echo
+echo "Static OpenSSL installed to ${PREFIX}"
+ls -la "${PREFIX}/lib/"libssl.a "${PREFIX}/lib/"libcrypto.a 2>/dev/null \
+  || ls -la "${PREFIX}"/lib*/libssl.a "${PREFIX}"/lib*/libcrypto.a

--- a/setup.py
+++ b/setup.py
@@ -57,17 +57,86 @@ def make_extension(name: str, sources: List[str]) -> Extension:
                      extra_link_args=extra_link_args)
 
 
+# Statically link a bundled OpenSSL into the ssl_object extension so aiofastnet
+# works on Python distributions whose _ssl is statically linked / has no
+# discoverable libssl (e.g. uv's python-build-standalone). See
+# scripts/build_openssl.sh and aiofastnet/openssl_bundled.c.
+#
+# Controlled by AIOFASTNET_BUNDLED_OPENSSL: "1" forces it on, "0" forces it off.
+# When unset, it is auto-enabled if (a) the *building* interpreter's _ssl is
+# statically linked (so the borrow backend cannot work at runtime) and (b) a
+# pre-built static OpenSSL is present at the prefix below -- so a plain
+# `setup.py build_ext` works after running scripts/build_openssl.sh.
+_openssl_prefix = os.environ.get(
+    "AIOFASTNET_OPENSSL_PREFIX",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "build", "openssl"),
+)
+
+
+def _static_openssl_present() -> bool:
+    lib_dir = os.path.join(_openssl_prefix, "lib")
+    return (os.path.exists(os.path.join(lib_dir, "libssl.a")) and
+            os.path.exists(os.path.join(lib_dir, "libcrypto.a")))
+
+
+def _interpreter_ssl_is_static() -> bool:
+    # Mirrors aiofastnet/openssl_compat.py: a builtin _ssl (no __file__) has no
+    # separate libssl to borrow at runtime.
+    try:
+        import _ssl
+    except ImportError:
+        return False
+    return getattr(_ssl, "__file__", None) is None
+
+
+_bundled_env = os.environ.get("AIOFASTNET_BUNDLED_OPENSSL")
+if _bundled_env is None:
+    bundled_openssl = _interpreter_ssl_is_static() and _static_openssl_present()
+    if bundled_openssl:
+        print("setup.py: auto-enabling bundled OpenSSL (static _ssl interpreter "
+              f"and static OpenSSL found at {_openssl_prefix})")
+else:
+    bundled_openssl = _bundled_env == "1"
+
+
+def make_ssl_object_extension() -> Extension:
+    sources = [
+        "aiofastnet/ssl_object.pyx",
+        "aiofastnet/static_mem_bio.c",
+        "aiofastnet/openssl_compat.c",
+    ]
+    if not bundled_openssl:
+        return make_extension("aiofastnet.ssl_object", sources)
+
+    openssl_prefix = _openssl_prefix
+    include_dir = os.path.join(openssl_prefix, "include")
+    lib_dir = os.path.join(openssl_prefix, "lib")
+    libssl = os.path.join(lib_dir, "libssl.a")
+    libcrypto = os.path.join(lib_dir, "libcrypto.a")
+    for path in (include_dir, libssl, libcrypto):
+        if not os.path.exists(path):
+            raise RuntimeError(
+                f"AIOFASTNET_BUNDLED_OPENSSL=1 but {path!r} is missing; "
+                f"build static OpenSSL first (scripts/build_openssl.sh) or set "
+                f"AIOFASTNET_OPENSSL_PREFIX")
+
+    return Extension(
+        "aiofastnet.ssl_object",
+        sources + ["aiofastnet/openssl_bundled.c"],
+        libraries=libs,
+        # libssl depends on libcrypto -> list libssl first.
+        define_macros=(macros or []) + [("AIOFASTNET_BUNDLED_OPENSSL", "1")],
+        include_dirs=[include_dir],
+        extra_objects=[libssl, libcrypto],
+        extra_compile_args=(extra_compile_args or []) + ["-fvisibility=hidden"],
+        extra_link_args=extra_link_args,
+    )
+
+
 extensions = [
     make_extension("aiofastnet.utils", ["aiofastnet/utils.pyx"]),
     make_extension("aiofastnet.transport", ["aiofastnet/transport.pyx"]),
-    make_extension(
-        "aiofastnet.ssl_object",
-        [
-            "aiofastnet/ssl_object.pyx",
-            "aiofastnet/static_mem_bio.c",
-            "aiofastnet/openssl_compat.c",
-        ],
-    ),
+    make_ssl_object_extension(),
     make_extension(
         "aiofastnet.ssl_transport",
         ["aiofastnet/ssl_transport.pyx"],

--- a/tests/test_ssl_object.py
+++ b/tests/test_ssl_object.py
@@ -32,6 +32,9 @@ class _InvalidSocket:
 
 
 def test_openssl_discovery_resolves_real_libraries():
+    if getattr(ssl_object, "BACKEND", None) == "bundled":
+        pytest.skip("borrow backend only: bundled OpenSSL has no discoverable libs")
+
     libs = openssl_compat.OPENSSL_DYN_LIBS
 
     assert os.path.exists(libs.libssl)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -583,7 +583,17 @@ def make_test_ssl_contexts(cert_file: Union[str, Path], key_file: Union[str, Pat
     cert_file = str(cert_file)
     key_file = str(key_file)
 
-    server_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    # On the bundled backend (statically linked OpenSSL) aiofastnet builds its own
+    # SSL_CTX and cannot read certs/ciphers/ALPN back from a plain ssl.SSLContext,
+    # so use aiofastnet.SSLContext, which records that config for replay. It is a
+    # drop-in ssl.SSLContext subclass; we only switch when bundled so the borrow
+    # backend keeps covering plain ssl.SSLContext.
+    import aiofastnet
+    from aiofastnet import ssl_object
+    bundled = getattr(ssl_object, "BACKEND", None) == "bundled"
+    server_ctx_cls = aiofastnet.SSLContext if bundled else ssl.SSLContext
+
+    server_context = server_ctx_cls(ssl.PROTOCOL_TLS_SERVER)
     server_context.load_cert_chain(certfile=cert_file, keyfile=key_file)
     server_context.minimum_version = ssl.TLSVersion.TLSv1_2
     server_context.maximum_version = ssl.TLSVersion.TLSv1_2
@@ -591,7 +601,10 @@ def make_test_ssl_contexts(cert_file: Union[str, Path], key_file: Union[str, Pat
     if enable_ktls:
         server_context.options |= ssl.OP_ENABLE_KTLS
 
-    client_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if bundled:
+        client_context = aiofastnet.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    else:
+        client_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     client_context.check_hostname = False
     client_context.verify_mode = ssl.CERT_NONE
     client_context.minimum_version = ssl.TLSVersion.TLSv1_2


### PR DESCRIPTION
## Summary
- add an opt-in/auto-detected bundled OpenSSL backend for Python builds that cannot expose a dynamic libssl, such as uv python-build-standalone
- add aiofastnet.SSLContext to record unrecoverable SSLContext configuration for replay onto aiofastnet's own SSL_CTX
- add server-context preflight, bundled ALPN handling, verify flag copying, cache invalidation, and bundled-backend test coverage

## Validation
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_ssl_object.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .
- git diff --check